### PR TITLE
Add `using` statement

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,7 @@ private bool IsUserAllowedToSeeMiniProfilerUI(HttpRequest httpRequest)
 						<div class="tab-pane" id="EF6">
 							<p>Install the <a href="https://www.nuget.org/packages/MiniProfiler.EF6/">MiniProfiler.EF6</a> nuget and use one line of code to initialize for all connections in the app:</p>
 <pre><code>using StackExchange.Profiling;
+using StackExchange.Profiling.EntityFramework6;
 ...    
 protected void Application_Start()
 {


### PR DESCRIPTION
You need to reference the EntityFramework6 namespace in order to use this piece of code. It was missing from the example.